### PR TITLE
Pad `@q` values with 'doz' in certain cases

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -391,17 +391,28 @@ const patq = (n) => {
   const buff = n.toArrayLike(Buffer)
 
   const chunked =
-    buff.length % 2 === 1 && buff.length !== 1
+    isOdd(buff.length) && buff.length > 1
     ? concat([[buff[0]]], chunk(buff.slice(1), 2))
     : chunk(buff, 2)
+
+  const prefixName = byts =>
+    isUndefined(byts[1])
+    ? getPrefix(0) + getSuffix(byts[0])
+    : getPrefix(byts[0]) + getSuffix(byts[1])
 
   const name = byts =>
     isUndefined(byts[1])
     ? getSuffix(byts[0])
     : getPrefix(byts[0]) + getSuffix(byts[1])
 
+  // zero-pad odd, >1 bytelength strings for ease of string comparison
+  const alg = pair =>
+    isOdd(pair.length) && chunked.length > 1
+    ? prefixName(pair)
+    : name(pair)
+
   return chunked.reduce((acc, elem) =>
-    acc + (acc === '~' ? '' : '-') + name(elem), '~')
+    acc + (acc === '~' ? '' : '-') + alg(elem), '~')
 }
 
 hex2patq = hex => patq(new bnjs(hex, 'hex'))

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -145,7 +145,7 @@ test('patq correctly encodes 0x102 as @q', () => {
 
 test('patq correctly encodes 0x10102 as @q', () => {
   let input = new bnjs('010102', 'hex');
-  let expected = '~nec-marbud';
+  let expected = '~doznec-marbud';
   expect(ob.patq(input)).toBe(expected);
 });
 

--- a/test/property.js
+++ b/test/property.js
@@ -13,6 +13,7 @@ eqModLeadingZeroBytes = (s, t) =>
   removeLeadingZeroBytes(s) === removeLeadingZeroBytes(t)
 
 describe('@q encoding', () => {
+
   let hexString = jsc.string.smap(
     x => Buffer.from(x).toString('hex'),
     x => Buffer.from(x, 'hex').toString()
@@ -32,7 +33,8 @@ describe('@q encoding', () => {
       ob.hex2patq(ob.patq2hex(str)) === str
     )
 
-    jsc.assert(iso0)
-    jsc.assert(iso1)
+    jsc.assert(iso0, { tests: 200 })
+    jsc.assert(iso1, { tests: 200 })
   })
+
 })


### PR DESCRIPTION
E.g., renders both the hex strings '010203' and '10203' as '~doznec-binwes', rather than the latter as '~nec-binwes'.  Note that both are considered equivalent in Hoon (i.e. `=(.~doznec-binwes .~nec-binwes)` is true).

(See urbit/arvo#824.)