### PR TITLE
Export isValidPatp, isValidPatq

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+- 3.1.0 (2018-11-16)
+    * Exports 'isValidPatp' and 'isValidPatq' functions for checking the
+      validity of @p and @q strings.
+
 - 3.0.0 (2018-11-02)
     * Major library cleanup and API simplification.  Eliminates old, dead,
       or redundant code that had accrued over time.  Exposes patp, patp2dec,

--- a/README.md
+++ b/README.md
@@ -31,13 +31,14 @@ down the dependencies.
 
 The library exposes two families of functions:
 
-* `patp / patp2dec / patp2hex / hex2patp`
-* `patq / patq2dec / patq2hex / hex2patq`
+* `patp / patp2dec / patp2hex / hex2patp / isValidPatp`
+* `patq / patq2dec / patq2hex / hex2patq / isValidPatq`
 
 They are pretty self-explanatory.  Use `patp` or `patq` to convert base-10
 numbers (or strings encoding base-10 numbers) to `@p` or `@q` respectively.
 Use `patp2dec` or `patq2dec` to go in reverse.  `patp2hex`, `patq2hex`, and
-their inverses work similarly.
+their inverses work similarly.  `isValidPat{p, q}` can be used to check the
+validity of a `@p` or `@q` string.
 
 Some examples:
 
@@ -51,6 +52,8 @@ Some examples:
 '~doznec-binwes'
 > ob.patq2hex('~marned-wismul-nilsev-botnyt')
 '01ca0e51d20462f3'
+> ob.isValidPatq('~marned-wismul-nilsev-botnyt')
+> true
 ```
 
 There are a few other noteworthy functions exposed as well:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbit-ob",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Utilities for Hoon-style atom printing and conversion",
   "main": "src/index.js",
   "scripts": {

--- a/src/internal/co.js
+++ b/src/internal/co.js
@@ -353,11 +353,11 @@ const sein = (name) => {
 /**
  * Weakly check if a string is a valid @p or @q value.
  *
- * This is, at present, a pretty weak internal sanity check.  It doesn't
- * confirm the structure precisely (e.g. dashes), and for @q, it's required
- * that q values of (greater than one) odd bytelength have been zero-padded.
- * So, for example, '~doznec-binwod' will be considered a valid @q, but
- * '~nec-binwod' will not.
+ * This is, at present, a pretty weak sanity check.  It doesn't confirm the
+ * structure precisely (e.g. dashes), and for @q, it's required that q values
+ * of (greater than one) odd bytelength have been zero-padded.  So, for
+ * example, '~doznec-binwod' will be considered a valid @q, but '~nec-binwod'
+ * will not.
  *
  * @param  {String}  name a @p or @q value
  * @return  {String}
@@ -419,5 +419,7 @@ module.exports = {
   patq2dec,
   clan,
   sein,
-  eqPatq
+  eqPatq,
+  isValidPatq: isValidPat, // reserving for diff impls in future
+  isValidPatp: isValidPat
 }

--- a/test/co.test.js
+++ b/test/co.test.js
@@ -12,7 +12,9 @@ const {
   patq2dec,
   clan,
   sein,
-  eqPatq
+  eqPatq,
+  isValidPatq,
+  isValidPatp
   } = require('../src/internal/co')
 
 const patps = jsc.uint32.smap(
@@ -199,3 +201,29 @@ describe('eqPatq', () => {
   })
 })
 
+describe('isValidPat{q, p}', () => {
+  it('isValidPatp returns true for valid @p values', () => {
+    expect(isValidPatp('~zod')).to.equal(true)
+    expect(isValidPatp('~marzod')).to.equal(true)
+    expect(isValidPatp('~nidsut-tomdun')).to.equal(true)
+  })
+
+  it('isValidPatp returns false for invalid @p values', () => {
+    expect(isValidPatp('~hu')).to.equal(false)
+    expect(isValidPatp('~what')).to.equal(false)
+    expect(isValidPatp('sudnit-duntom')).to.equal(false)
+  })
+
+  it('isValidPatq returns true for valid @p values', () => {
+    expect(isValidPatq('~zod')).to.equal(true)
+    expect(isValidPatq('~marzod')).to.equal(true)
+    expect(isValidPatq('~nidsut-tomdun')).to.equal(true)
+    expect(isValidPatq('~dozzod-binwes-nidsut-tomdun')).to.equal(true)
+  })
+
+  it('isValidPatq returns false for invalid @p values', () => {
+    expect(isValidPatq('~hu')).to.equal(false)
+    expect(isValidPatq('~what')).to.equal(false)
+    expect(isValidPatq('sudnit-duntom')).to.equal(false)
+  })
+})


### PR DESCRIPTION
These are both at present the same underlying sanity check, rather than the results of strict `@p` and `@q` parsers.  They're all I need for the time being, and can be upgraded in the future.