### PR TITLE
Make patp2syls always return array result

### DIFF
--- a/src/internal/co.js
+++ b/src/internal/co.js
@@ -53,7 +53,8 @@ lyrtesmudnytbyrsenwegfyrmurtelreptegpecnelnevfes\
 `
 
 const patp2syls = name =>
-  (name.replace(/[\^~-]/g,'').match(/.{1,3}/g) || [])
+     name.replace(/[\^~-]/g,'').match(/.{1,3}/g)
+  || []
 
 const splitAt = (index, str) => [str.slice(0, index), str.slice(index)]
 
@@ -361,13 +362,12 @@ const isValidPat = name => {
     throw new Error('isValidPat: non-string input')
   }
 
-  const syls = patp2syls(name)
-
   const leadingTilde = name.slice(0, 1) === '~'
 
-  if (leadingTilde === false) {
+  if (leadingTilde === false || name.length < 3) {
     return false
   } else {
+    const syls = patp2syls(name)
     const wrongLength = syls.length % 2 !== 0 && syls.length !== 1
     const sylsExist = lodash.reduce(syls, (acc, syl, index) =>
       acc &&

--- a/src/internal/co.js
+++ b/src/internal/co.js
@@ -53,7 +53,7 @@ lyrtesmudnytbyrsenwegfyrmurtelreptegpecnelnevfes\
 `
 
 const patp2syls = name =>
-  name.replace(/[\^~-]/g,'').match(/.{1,3}/g)
+  (name.replace(/[\^~-]/g,'').match(/.{1,3}/g) || [])
 
 const splitAt = (index, str) => [str.slice(0, index), str.slice(index)]
 

--- a/test/co.test.js
+++ b/test/co.test.js
@@ -215,6 +215,7 @@ describe('isValidPat{q, p}', () => {
 
   it('isValidPatp returns false for invalid @p values', () => {
     expect(isValidPatp('')).to.equal(false)
+    expect(isValidPatp('~')).to.equal(false)
     expect(isValidPatp('~hu')).to.equal(false)
     expect(isValidPatp('~what')).to.equal(false)
     expect(isValidPatp('sudnit-duntom')).to.equal(false)
@@ -229,6 +230,7 @@ describe('isValidPat{q, p}', () => {
 
   it('isValidPatq returns false for invalid @p values', () => {
     expect(isValidPatq('')).to.equal(false)
+    expect(isValidPatq('~')).to.equal(false)
     expect(isValidPatq('~hu')).to.equal(false)
     expect(isValidPatq('~what')).to.equal(false)
     expect(isValidPatq('sudnit-duntom')).to.equal(false)


### PR DESCRIPTION
Could otherwise return null, crashing in cases like isValidPat('~')