### PR TITLE
Add a simple API test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "urbit-ob",
-  "version": "4.0.2",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,29 @@
+const ob = require('../src')
+const { expect } = require('chai')
+
+describe('the public-facing API', () => {
+
+  const zod = '~zod'
+  const zoddec = '0'
+  const zodhex = '00'
+  const zodclan = 'galaxy'
+
+  it('contains the appropriate exports', () => {
+    expect(ob.patp(zoddec)).to.equal(zod)
+    expect(ob.patp2hex(zod)).to.equal(zodhex)
+    expect(ob.hex2patp(zodhex)).to.equal(zod)
+    expect(ob.patp2dec(zod)).to.equal(zoddec)
+    expect(ob.sein(zod)).to.equal(zod)
+    expect(ob.clan(zod)).to.equal(zodclan)
+
+    expect(ob.patq(zoddec)).to.equal(zod)
+    expect(ob.patq2hex(zod)).to.equal(zodhex)
+    expect(ob.hex2patq(zodhex)).to.equal(zod)
+    expect(ob.patq2dec(zod)).to.equal(zoddec)
+
+    expect(ob.eqPatq(zod, zod)).to.equal(true)
+    expect(ob.isValidPatp(zod)).to.equal(true)
+    expect(ob.isValidPatq(zod)).to.equal(true)
+  })
+})
+


### PR DESCRIPTION
An innocent-looking change made in c8b0a8d wound up borking the API in a way that was not detectable through the test suite.  This just adds a test that confirms that the claimed exported functions are really exported.